### PR TITLE
feat(webview): handle window.open

### DIFF
--- a/src/stremio_app/stremio_wevbiew/wevbiew.rs
+++ b/src/stremio_app/stremio_wevbiew/wevbiew.rs
@@ -137,6 +137,23 @@ impl PartialUi for WebView {
                                     }
                                     })
                             }catch(e){}
+
+                            window.open = (url) => {
+                                if (typeof url === 'string' && URL.canParse(url)) 
+                                    return console.error('Not a valid URL string');
+
+                                try {
+                                    const message = {
+                                        id: 1,
+                                        args: ['open-external', url],
+                                    };
+
+                                    window.chrome.webview.postMessage(JSON.stringify(message));
+                                } catch(e) {
+                                    console.error('Failed to post message');
+                                }
+                            };
+
                             try{console.log('Shell JS injected');if(window.self === window.top) {
                                 window.qt={webChannelTransport:{send:window.chrome.webview.postMessage}};
                                 window.chrome.webview.addEventListener('message',ev=>window.qt.webChannelTransport.onmessage(ev));


### PR DESCRIPTION
Allow the web app to use `window.open()` instead of using the ipc transport