### PR TITLE
Player: Added demuxer cache time

### DIFF
--- a/src/stremio_app/stremio_player/communication.rs
+++ b/src/stremio_app/stremio_player/communication.rs
@@ -185,6 +185,7 @@ pub enum FpProp {
     SubDelay,
     SubScale,
     CacheBufferingState,
+    DemuxerCacheTime,
     SubPos,
     Speed,
 }


### PR DESCRIPTION
This change allows `stremio-video` `ShellVideo` to use `demuxer-cache-time` to get `buffered` value.

