### PR TITLE
fix(Player): stop fabricating end-file on transient mpv event errors

### DIFF
--- a/src/stremio_app/stremio_player/communication.rs
+++ b/src/stremio_app/stremio_player/communication.rs
@@ -61,21 +61,14 @@ impl PlayerEnded {
             _ => "other".to_string(),
         }
     }
-    pub fn from_end_reason(data: EndFileReason, error: &str) -> Self {
+    pub fn from_end_reason(data: EndFileReason) -> Self {
         Self {
             reason: Self::string_from_end_reason(data),
             error: if data == mpv_end_file_reason::Error {
-                if error.is_empty() {
-                    Some(PlayerEndedError {
-                        message: "Unknown error".to_string(),
-                        critical: true,
-                    })
-                } else {
-                    Some(PlayerEndedError {
-                        message: error.to_string(),
-                        critical: true,
-                    })
-                }
+                Some(PlayerEndedError {
+                    message: "Unknown error".to_string(),
+                    critical: false,
+                })
             } else {
                 None
             },

--- a/src/stremio_app/stremio_player/communication_tests.rs
+++ b/src/stremio_app/stremio_player/communication_tests.rs
@@ -75,7 +75,7 @@ fn ended_tokens() {
         Token::Str("message"),
         Token::Str("Unknown error"),
         Token::Str("critical"),
-        Token::Bool(true),
+        Token::Bool(false),
         Token::StructEnd,
         Token::StructEnd,
     ];
@@ -89,11 +89,11 @@ fn ended_tokens() {
         Token::StructEnd,
     ];
     assert_tokens(
-        &PlayerEnded::from_end_reason(mpv_end_file_reason::Error, ""),
+        &PlayerEnded::from_end_reason(mpv_end_file_reason::Error),
         &error_tokens,
     );
     assert_tokens(
-        &PlayerEnded::from_end_reason(mpv_end_file_reason::Quit, ""),
+        &PlayerEnded::from_end_reason(mpv_end_file_reason::Quit),
         &tokens,
     );
 }

--- a/src/stremio_app/stremio_player/player.rs
+++ b/src/stremio_app/stremio_player/player.rs
@@ -103,20 +103,11 @@ fn create_event_thread(
             }
 
             // -1.0 means to block and wait for an event.
-            let (event, error) = match event_context.wait_event(-1.) {
-                Some(Ok(event)) => (event, ""),
+            let event = match event_context.wait_event(-1.) {
+                Some(Ok(event)) => event,
                 Some(Err(error)) => {
-                    if let libmpv2::Error::Raw(e) = error {
-                        (
-                            Event::EndFile(
-                                libmpv2_sys::mpv_end_file_reason_MPV_END_FILE_REASON_ERROR,
-                            ),
-                            libmpv2_sys::mpv_error_str(e),
-                        )
-                    } else {
-                        eprintln!("Unhandled event error: {error:?}");
-                        continue;
-                    }
+                    eprintln!("Event errored: {error:?}");
+                    continue;
                 }
                 // dummy event received (may be created on a wake up call or on timeout)
                 None => continue,
@@ -133,7 +124,7 @@ fn create_event_thread(
                 ),
                 Event::EndFile(reason) => PlayerResponse(
                     "mpv-event-ended",
-                    PlayerEvent::End(PlayerEnded::from_end_reason(reason, error)),
+                    PlayerEvent::End(PlayerEnded::from_end_reason(reason)),
                 ),
                 Event::Shutdown => {
                     break;


### PR DESCRIPTION
Commit 0b882f3 synthesized an Event::EndFile(Error) whenever
event_context.wait_event returned libmpv2::Error::Raw and forwarded it
to the web layer. MPV is fully able to continue playback after such
transient errors (its demuxer cache is intact), so fabricating an
end-of-file caused long-running HTTP streams (e.g. RealDebrid) to flip
to a blocking "Loading failed" overlay mid-playback. Revert that branch
to the prior log-and-continue behavior.

Also downgrade PlayerEnded errors from critical:true to critical:false
so genuine mpv_end_file_reason::Error surfaces as a 3s toast in
stremio-web (Player.js), letting the user retry, instead of an
unrecoverable full-screen overlay.