### PR TITLE
Player: allow setting mpv vf property for RTX Auto HDR / VSR support

### DIFF
--- a/src/stremio_app/stremio_player/communication.rs
+++ b/src/stremio_app/stremio_player/communication.rs
@@ -203,6 +203,7 @@ pub enum StrProp {
     SubBorderColor,
     SubColor,
     TrackList,
+    Vf,
     VideoParams,
     Vo,
 }


### PR DESCRIPTION
# Expose `vf` property over IPC

This PR adds backend support for updating `vf` (mpv's video filter chain) from the frontend — enabling things like NVIDIA RTX Auto HDR and RTX VSR (Video Super Resolution) once the corresponding toggles land in `stremio-web`.

Concretely: adds `Vf` to the `StrProp` allowlist in `stremio_player::communication` so the web UI can send `["mpv-set-prop", ["vf", "..."]]` through the existing IPC path. No behavior changes by default.

## Example

Once this lands, the web UI can wire up RTX Auto HDR and RTX VSR toggles by sending the matching `mpv-set-prop` messages. For example, to enable both at once:

```js
// RTX Auto HDR + RTX VSR (NVIDIA RTX 30/40-series, Windows HDR on)
["mpv-set-prop", ["hwdec", "d3d11va"]]
["mpv-set-prop", ["vf",    "d3d11vpp=scaling-mode=nvidia:scale=1:format=x2bgr10:nvidia-true-hdr"]]
```

Or just RTX VSR (upscaling only, no HDR conversion):

```js
["mpv-set-prop", ["hwdec", "d3d11va"]]
["mpv-set-prop", ["vf",    "d3d11vpp=scaling-mode=nvidia:scale=1"]]
```

Toggling off:

```js
["mpv-set-prop", ["hwdec", "auto"]]
["mpv-set-prop", ["vf",    ""]]
```

`hwdec` and `vo` were already on the allowlist; `vf` was the missing piece. The existing `vo` special-case in `player.rs` already auto-appends `gpu-next` (which `d3d11vpp` requires), so the web UI doesn't need to manage that.

**Note:** updating the bundled libmpv is required. The current bundle (`v0.40.0-465`) produces purple frames when the `d3d11vpp` filter is engaged in embedded mode; this is fixed in mpv `v0.41+`.

---

*AI was used to assist with this change (research, debugging, and drafting).*



Related #58
