### PR TITLE
Fix peer-death command drop on single-instance forwarding

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -88,8 +88,15 @@ fn main() {
     commands_path.push_str(&username());
     let socket_path = Path::new(&commands_path);
     if let Ok(mut stream) = PipeClient::connect(socket_path) {
-        stream.write_all(command.as_bytes()).ok();
-        exit(0);
+        let forwarded = stream
+            .write_all(command.as_bytes())
+            .and_then(|_| stream.flush())
+            .is_ok();
+        drop(stream);
+        if forwarded {
+            exit(0);
+        }
+        eprintln!("Failed to forward command to existing Stremio instance; launching new instance");
     }
     // END IPC
 


### PR DESCRIPTION
## Problem

After `PipeClient::connect` succeeds, `write_all(...).ok()` ignored the failure result and unconditionally `exit(0)`. If the peer instance dies between connect and write, the user's launch command (a deep link, file path, etc.) is silently dropped and no shell launches at all.

## Changes

- Capture the result of `write_all` + `flush` instead of swallowing it.
- Only `exit(0)` when the command was actually delivered.
- Otherwise log the failure and fall through to launching this process.

Closes #45

## Test

- `cargo check --target x86_64-pc-windows-msvc`
- `cargo clippy --target x86_64-pc-windows-msvc`
