### PR TITLE
Fix PipeServer bind on stale handles

### DIFF
--- a/src/stremio_app/app.rs
+++ b/src/stremio_app/app.rs
@@ -218,7 +218,16 @@ impl MainWindow {
             }
         }); // thread
 
-        if let Ok(mut listener) = PipeServer::bind(socket_path) {
+        // Retry: a stale FIRST_PIPE_INSTANCE handle returns ERROR_ACCESS_DENIED briefly.
+        let listener = (0..5).find_map(|attempt| match PipeServer::bind(socket_path) {
+            Ok(listener) => Some(listener),
+            Err(err) => {
+                eprintln!("PipeServer::bind failed (attempt {}): {err}", attempt + 1);
+                thread::sleep(time::Duration::from_millis(100 * (attempt + 1)));
+                None
+            }
+        });
+        if let Some(mut listener) = listener {
             let focus_sender = self.focus_notice.sender();
             thread::spawn(move || loop {
                 if let Ok(mut stream) = listener.accept() {
@@ -232,6 +241,8 @@ impl MainWindow {
                     }
                 }
             });
+        } else {
+            eprintln!("PipeServer::bind failed after retries; single-instance forwarding disabled");
         }
 
         // Read message from player


### PR DESCRIPTION
## Problem

`PipeServer::bind` was attempted once with no retry. A stale pipe handle from a not-fully-cleaned-up previous instance causes `CreateNamedPipeW` with `FILE_FLAG_FIRST_PIPE_INSTANCE` to fail with `ERROR_ACCESS_DENIED` until the kernel releases the handle. The single-instance forwarder thread was then never spawned and later launches silently fell through to spawning a second app.

## Changes

- Retry `PipeServer::bind` up to 5 times with linear backoff (100ms–500ms).
- Log when retries are exhausted so the silent-fallthrough mode is visible in diagnostics.

Closes #56

## Test

- `cargo check --target x86_64-pc-windows-msvc`
- `cargo clippy --target x86_64-pc-windows-msvc`