### PR TITLE
Fix server reader IO error loop

### DIFF
--- a/src/stremio_app/stremio_server/server.rs
+++ b/src/stremio_app/stremio_server/server.rs
@@ -85,10 +85,14 @@ impl StremioServer {
                         let http_endpoint = String::new();
                         loop {
                             let mut buffer = [0; SRV_BUFFER_SIZE];
-                            let on = stdout.read(&mut buffer[..]).unwrap_or(!0);
-                            if on > buffer.len() {
-                                continue;
-                            }
+                            let on = match stdout.read(&mut buffer[..]) {
+                                Ok(0) => break,
+                                Ok(n) => n,
+                                Err(err) => {
+                                    eprintln!("server stdout read error: {err}");
+                                    break;
+                                }
+                            };
                             std::io::stdout().write_all(&buffer).ok();
                             let string_data = String::from_utf8_lossy(&buffer[..on]);
                             {
@@ -116,10 +120,6 @@ impl StremioServer {
                                     .collect::<Vec<&str>>()
                                     .join("\n");
                             };
-                            if on == 0 {
-                                // Server terminated
-                                break;
-                            }
                         }
                     });
 
@@ -128,10 +128,14 @@ impl StremioServer {
                     let err_thread = thread::spawn(move || {
                         let mut buffer = [0; SRV_BUFFER_SIZE];
                         loop {
-                            let en = stderr.read(&mut buffer[..]).unwrap_or(!0);
-                            if en > buffer.len() {
-                                continue;
-                            }
+                            let en = match stderr.read(&mut buffer[..]) {
+                                Ok(0) => break,
+                                Ok(n) => n,
+                                Err(err) => {
+                                    eprintln!("server stderr read error: {err}");
+                                    break;
+                                }
+                            };
                             std::io::stderr().write_all(&buffer).ok();
                             let string_data = String::from_utf8_lossy(&buffer[..en]);
                             // eprint!("{:?}", &buffer);
@@ -148,10 +152,6 @@ impl StremioServer {
                                     .collect::<Vec<&str>>()
                                     .join("\n");
                             };
-                            if en == 0 {
-                                // Server terminated
-                                break;
-                            }
                         }
                     });
                     out_thread.join().ok();


### PR DESCRIPTION
## Problem

`stdout.read(...).unwrap_or(!0)` substituted `usize::MAX` on Err, then `if on > buffer.len() { continue; }` swallowed it and looped back into `read()`. On a sticky IO error (broken pipe, EBADF) the thread spun a CPU core forever and the accumulated logs were never flushed to the crash dialog.

## Changes

- Match `Ok(0)` / `Ok(n)` / `Err(e)` explicitly: break on EOF, break on error after logging, treat any other `Ok(n)` as bytes read.
- Same change for the stderr reader.

Closes #51

## Test

- `cargo check --target x86_64-pc-windows-msvc`
- `cargo clippy --target x86_64-pc-windows-msvc`