### PR TITLE
Fix stremio-runtime child reaping

### DIFF
--- a/src/stremio_app/stremio_server/server.rs
+++ b/src/stremio_app/stremio_server/server.rs
@@ -178,6 +178,9 @@ impl StremioServer {
                     });
                     out_thread.join().ok();
                     err_thread.join().ok();
+                    // Drop on Windows neither kills nor waits, so reap explicitly.
+                    child.kill().ok();
+                    child.wait().ok();
                 }
                 Err(err) => {
                     nwg::error_message(


### PR DESCRIPTION
## Problem

After both stdout and stderr readers exited, the `Child` handle was just dropped at the end of the match arm. On Windows `std::process::Child`'s `Drop` neither kills nor waits, so the OS process kept its kernel object (and its bound ports) alive until either the JobObject `KILL_ON_JOB_CLOSE` fired on shell exit or init adopted it.

In the crash-restart path this is worse: a fresh `start()` is launched while the previous runtime is still being reaped, and both processes race for port 11470.

## Changes

- Explicitly `kill().ok()` + `wait().ok()` once the readers see EOF.
- Errors from killing an already-exited child are intentionally swallowed.

Closes #50

## Stacked on

#64 (Fix JobObject HANDLE leak and ignored return values)

## Test

- `cargo check --target x86_64-pc-windows-msvc`
- `cargo clippy --target x86_64-pc-windows-msvc`