### PR TITLE
Fix StremioServer::start idempotency

### DIFF
--- a/src/stremio_app/stremio_server/server.rs
+++ b/src/stremio_app/stremio_server/server.rs
@@ -8,7 +8,10 @@ use std::{
     os::windows::process::CommandExt,
     path,
     process::{Command, Stdio},
-    sync::{Arc, Mutex, Once},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex, Once,
+    },
     thread,
 };
 use winapi::um::{
@@ -71,6 +74,7 @@ pub struct StremioServer {
     parent: nwg::ControlHandle,
     crash_notice: nwg::Notice,
     logs: Arc<Mutex<String>>,
+    running: Arc<AtomicBool>,
 }
 
 impl StremioServer {
@@ -78,9 +82,14 @@ impl StremioServer {
         if self.development {
             return;
         }
+        if self.running.swap(true, Ordering::SeqCst) {
+            eprintln!("StremioServer::start() called while a server is already running; skipping");
+            return;
+        }
         let (tx, rx) = flume::unbounded();
         let logs = self.logs.clone();
         let sender = self.crash_notice.sender();
+        let running = self.running.clone();
 
         ensure_parent_job_object();
 
@@ -205,6 +214,8 @@ impl StremioServer {
                 let mut logs = logs.lock().unwrap();
                 *logs = lines.lock().unwrap().deref().to_string();
             }
+            // Clear before sender.notice() so the next start() can pass the swap guard.
+            running.store(false, Ordering::SeqCst);
             println!("Server terminated.");
             sender.notice();
         });


### PR DESCRIPTION
## Problem

`start()` unconditionally spawned a fresh `stremio-runtime` every time it was called. Today only the GUI thread calls it, but the crash-restart path can re-fire `start()` while the previous teardown is still in progress, racing two runtimes for port 11470.

## Changes

- Track a `running: Arc<AtomicBool>` on the struct.
- `swap(true)` on entry, bail with a log if the previous server thread has not yet flipped it back to `false`.
- Reset to `false` right before `sender.notice()` so the GUI's crash handler can legitimately spawn the next instance.

Closes #57

## Stacked on

#66 (Fix split server readiness detection)

## Test

- `cargo check --target x86_64-pc-windows-msvc`
- `cargo clippy --target x86_64-pc-windows-msvc`