### PR TITLE
Fix stremio-runtime server lifecycle issues

### DIFF
--- a/src/stremio_app/stremio_server/server.rs
+++ b/src/stremio_app/stremio_server/server.rs
@@ -178,6 +178,9 @@ impl StremioServer {
                     });
                     out_thread.join().ok();
                     err_thread.join().ok();
+                    // Drop on Windows neither kills nor waits, so reap explicitly.
+                    child.kill().ok();
+                    child.wait().ok();
                 }
                 Err(err) => {
                     nwg::error_message(

--- a/src/stremio_app/stremio_server/server.rs
+++ b/src/stremio_app/stremio_server/server.rs
@@ -2,13 +2,13 @@ use crate::stremio_app::constants::{SRV_BUFFER_SIZE, SRV_LOG_SIZE, STREMIO_SERVE
 use native_windows_gui::{self as nwg, PartialUi};
 use std::io::Write;
 use std::{
-    env, fs,
+    env, fs, io,
     io::Read,
     ops::Deref,
     os::windows::process::CommandExt,
     path,
     process::{Command, Stdio},
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, Once},
     thread,
 };
 use winapi::um::{
@@ -20,6 +20,50 @@ use winapi::um::{
         JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
     },
 };
+
+// Guarded by Once: avoids HANDLE leak per crash and re-assignment failure on Win 7/8.
+fn ensure_parent_job_object() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| unsafe {
+        let job = CreateJobObjectA(std::ptr::null_mut(), std::ptr::null_mut());
+        if job.is_null() {
+            eprintln!(
+                "CreateJobObjectA failed: {}; child stremio-runtime may outlive the shell on crash",
+                io::Error::last_os_error()
+            );
+            return;
+        }
+        let jeli = JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
+            BasicLimitInformation: JOBOBJECT_BASIC_LIMIT_INFORMATION {
+                LimitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+                    | JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
+                    | JOB_OBJECT_LIMIT_BREAKAWAY_OK,
+                ..std::mem::zeroed()
+            },
+            ..std::mem::zeroed()
+        };
+        if winapi::um::jobapi2::SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            &jeli as *const _ as *mut _,
+            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+        ) == 0
+        {
+            eprintln!(
+                "SetInformationJobObject failed: {}",
+                io::Error::last_os_error()
+            );
+            return;
+        }
+        if winapi::um::jobapi2::AssignProcessToJobObject(job, GetCurrentProcess()) == 0 {
+            eprintln!(
+                "AssignProcessToJobObject failed: {}; child stremio-runtime may outlive the shell",
+                io::Error::last_os_error()
+            );
+        }
+        // Don't CloseHandle: KILL_ON_JOB_CLOSE would terminate the shell itself.
+    });
+}
 
 #[derive(Default)]
 pub struct StremioServer {
@@ -38,31 +82,9 @@ impl StremioServer {
         let logs = self.logs.clone();
         let sender = self.crash_notice.sender();
 
+        ensure_parent_job_object();
+
         thread::spawn(move || {
-            // Use Win32JobObject to kill the child process when the parent process is killed
-            // With the JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK and JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE flags
-            unsafe {
-                let job_main_process = CreateJobObjectA(std::ptr::null_mut(), std::ptr::null_mut());
-                let jeli = JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
-                    BasicLimitInformation: JOBOBJECT_BASIC_LIMIT_INFORMATION {
-                        LimitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
-                            | JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
-                            | JOB_OBJECT_LIMIT_BREAKAWAY_OK,
-                        ..std::mem::zeroed()
-                    },
-                    ..std::mem::zeroed()
-                };
-                winapi::um::jobapi2::SetInformationJobObject(
-                    job_main_process,
-                    JobObjectExtendedLimitInformation,
-                    &jeli as *const _ as *mut _,
-                    std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
-                );
-                winapi::um::jobapi2::AssignProcessToJobObject(
-                    job_main_process,
-                    GetCurrentProcess(),
-                );
-            }
             let mut path = env::current_exe()
                 .and_then(fs::canonicalize)
                 .expect("Cannot get the current executable path");

--- a/src/stremio_app/stremio_server/server.rs
+++ b/src/stremio_app/stremio_server/server.rs
@@ -8,7 +8,10 @@ use std::{
     os::windows::process::CommandExt,
     path,
     process::{Command, Stdio},
-    sync::{Arc, Mutex, Once},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex, Once,
+    },
     thread,
 };
 use winapi::um::{
@@ -71,6 +74,7 @@ pub struct StremioServer {
     parent: nwg::ControlHandle,
     crash_notice: nwg::Notice,
     logs: Arc<Mutex<String>>,
+    running: Arc<AtomicBool>,
 }
 
 impl StremioServer {
@@ -78,9 +82,14 @@ impl StremioServer {
         if self.development {
             return;
         }
+        if self.running.swap(true, Ordering::SeqCst) {
+            eprintln!("StremioServer::start() called while a server is already running; skipping");
+            return;
+        }
         let (tx, rx) = flume::unbounded();
         let logs = self.logs.clone();
         let sender = self.crash_notice.sender();
+        let running = self.running.clone();
 
         ensure_parent_job_object();
 
@@ -205,6 +214,8 @@ impl StremioServer {
                 let mut logs = logs.lock().unwrap();
                 *logs = lines.lock().unwrap().deref().to_string();
             }
+            // Clear before sender.notice() so the next start() can pass the swap guard.
+            running.store(false, Ordering::SeqCst);
             println!("Server terminated.");
             sender.notice();
         });

--- a/src/stremio_app/stremio_server/server.rs
+++ b/src/stremio_app/stremio_server/server.rs
@@ -78,13 +78,14 @@ pub struct StremioServer {
 }
 
 impl StremioServer {
-    pub fn start(&self) {
+    /// Spawn the streaming server; recv on the returned receiver to wait for readiness.
+    pub fn start(&self) -> Option<flume::Receiver<String>> {
         if self.development {
-            return;
+            return None;
         }
         if self.running.swap(true, Ordering::SeqCst) {
             eprintln!("StremioServer::start() called while a server is already running; skipping");
-            return;
+            return None;
         }
         let (tx, rx) = flume::unbounded();
         let logs = self.logs.clone();
@@ -220,8 +221,7 @@ impl StremioServer {
             sender.notice();
         });
 
-        // Wait for the server to start
-        rx.recv().unwrap();
+        Some(rx)
     }
 }
 
@@ -240,7 +240,10 @@ impl PartialUi for StremioServer {
             .parent(data.parent)
             .build(&mut data.crash_notice)
             .ok();
-        data.start();
+        // Block until ready so the WebView isn't attached against an unbound port.
+        if let Some(rx) = data.start() {
+            rx.recv().ok();
+        }
         println!("Stremio server started");
         Ok(())
     }
@@ -257,6 +260,7 @@ impl PartialUi for StremioServer {
                 "Stremio server crash log",
                 self.logs.lock().unwrap().deref(),
             );
+            // Don't block: this runs on the GUI message pump.
             self.start();
         }
     }

--- a/src/stremio_app/stremio_server/server.rs
+++ b/src/stremio_app/stremio_server/server.rs
@@ -104,7 +104,7 @@ impl StremioServer {
                     let out_lines = lines.clone();
                     let tx = tx.clone();
                     let out_thread = thread::spawn(move || {
-                        let http_endpoint = String::new();
+                        let mut endpoint_sent = false;
                         loop {
                             let mut buffer = [0; SRV_BUFFER_SIZE];
                             let on = match stdout.read(&mut buffer[..]) {
@@ -120,19 +120,21 @@ impl StremioServer {
                             {
                                 let lines = &mut *out_lines.lock().unwrap();
                                 *lines += string_data.deref();
-                                if http_endpoint.is_empty() {
-                                    if let Some(http_endpoint) = string_data
+                                if !endpoint_sent {
+                                    if let Some(line) = lines
                                         .lines()
                                         .find(|line| line.starts_with("EngineFS server started at"))
                                     {
-                                        let http_endpoint =
-                                            http_endpoint.split_whitespace().last().unwrap();
-                                        println!("HTTP endpoint: {http_endpoint}");
-                                        let endpoint = http_endpoint.to_string();
-                                        tx.send(endpoint.clone()).ok();
+                                        if let Some(endpoint) = line.split_whitespace().last() {
+                                            println!("HTTP endpoint: {endpoint}");
+                                            tx.send(endpoint.to_string()).ok();
+                                            endpoint_sent = true;
+                                        }
                                     }
                                 }
-                                *lines = lines
+                                // Preserve trailing newline so the next chunk can't glue onto an unterminated line.
+                                let had_trailing_newline = lines.ends_with('\n');
+                                let mut trimmed = lines
                                     .lines()
                                     .rev()
                                     .take(SRV_LOG_SIZE)
@@ -141,6 +143,10 @@ impl StremioServer {
                                     .rev()
                                     .collect::<Vec<&str>>()
                                     .join("\n");
+                                if had_trailing_newline {
+                                    trimmed.push('\n');
+                                }
+                                *lines = trimmed;
                             };
                         }
                     });
@@ -164,7 +170,8 @@ impl StremioServer {
                             {
                                 let lines = &mut *err_lines.lock().unwrap();
                                 *lines += string_data.deref();
-                                *lines = lines
+                                let had_trailing_newline = lines.ends_with('\n');
+                                let mut trimmed = lines
                                     .lines()
                                     .rev()
                                     .take(SRV_LOG_SIZE)
@@ -173,6 +180,10 @@ impl StremioServer {
                                     .rev()
                                     .collect::<Vec<&str>>()
                                     .join("\n");
+                                if had_trailing_newline {
+                                    trimmed.push('\n');
+                                }
+                                *lines = trimmed;
                             };
                         }
                     });


### PR DESCRIPTION
Consolidates the server lifecycle fixes originally stacked as PRs #64 through #68.

Includes:
- Guard JobObject setup with Once and check HANDLE return values.
- Kill and wait for the stremio-runtime child after reader threads finish.
- Search accumulated server logs for split readiness lines.
- Guard StremioServer::start() with a running flag.
- Keep crash-restart work off the GUI message-pump thread.