### PR TITLE
Fix v4/v5 server coexistence (runtime detection)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,17 @@ fn main() {
     }
     // END IPC
 
+    // v4 has a different mutex name; the IPC check above won't catch it.
+    if detect_stremio_on_default_port() {
+        nwg::init().ok();
+        nwg::error_message(
+            "Stremio is already running",
+            "Another Stremio instance (v4) appears to be running on port 11470.\n\
+             Please close it before launching this version.",
+        );
+        exit(1);
+    }
+
     std::env::set_var(
         STREMIO_SERVER_DEV_MODE,
         if opt.development { "true" } else { "false" },
@@ -121,4 +132,23 @@ fn main() {
     })
     .expect("Failed to build UI");
     nwg::dispatch_thread_events();
+}
+
+/// Returns true if a Stremio streaming server is bound on 11470.
+fn detect_stremio_on_default_port() -> bool {
+    let client = match reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_millis(500))
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return false,
+    };
+    match client.get("http://127.0.0.1:11470/settings").send() {
+        Ok(resp) if resp.status().is_success() => match resp.text() {
+            // Both keys present rules out foreign processes (VPN, proxy) on 11470.
+            Ok(body) => body.contains("\"baseUrl\"") && body.contains("\"options\""),
+            Err(_) => false,
+        },
+        _ => false,
+    }
 }


### PR DESCRIPTION
## Problem

v4 and v5 use different mutex names and named pipes, so the single-instance forwarding earlier in `main()` does not see a running v4. Both versions then share the same on-disk cache and addon collection: `server.js` falls back to 11471, the WebUI keeps talking to `localhost:11470` (v4), and config writes from both processes corrupt each other.

## Changes

- Probe `http://127.0.0.1:11470/settings` after the named-pipe forwarding check.
- The Stremio streaming server replies with a JSON document that contains both `"baseUrl"` and `"options"`; a foreign process (VPN, proxy) will not. If the signature matches, surface a clear modal error and exit instead of silently launching alongside.

This is the runtime half of the fix; the installer's v4 detection and protocol-handler migration is tracked separately.

Closes #46

## Test

- `cargo check --target x86_64-pc-windows-msvc`
- `cargo clippy --target x86_64-pc-windows-msvc`