### PR TITLE
Player: launch external player via play-external IPC

### DIFF
--- a/src/stremio_app/app.rs
+++ b/src/stremio_app/app.rs
@@ -298,6 +298,52 @@ impl MainWindow {
                             }
                         }
                     }
+                    Some("play-external") => {
+                        if let Some(arg) = msg.get_params() {
+                            let arg = arg.as_str().unwrap_or("");
+                            let arg_lc = arg.to_lowercase();
+                            const ALLOWED_SCHEMES: &[&str] = &["mpv://", "vlc://", "potplayer://"];
+                            let allowed = ALLOWED_SCHEMES.iter().any(|s| arg_lc.starts_with(s));
+                            if !arg.is_empty() && allowed {
+                                if let Some(stream_url) =
+                                    arg_lc.starts_with("mpv://").then(|| &arg[6..])
+                                {
+                                    // `--` ends mpv's option parsing; the stream URL can't smuggle flags.
+                                    let mpv_paths: Vec<String> = vec![
+                                        std::env::var("ProgramFiles")
+                                            .ok()
+                                            .map(|v| format!("{v}\\mpv\\mpv.exe")),
+                                        std::env::var("ProgramFiles(x86)")
+                                            .ok()
+                                            .map(|v| format!("{v}\\mpv\\mpv.exe")),
+                                        std::env::var("LOCALAPPDATA")
+                                            .ok()
+                                            .map(|v| format!("{v}\\Programs\\mpv\\mpv.exe")),
+                                        std::env::var("LOCALAPPDATA")
+                                            .ok()
+                                            .map(|v| format!("{v}\\mpv\\mpv.exe")),
+                                        Some("mpv.exe".to_string()),
+                                    ]
+                                    .into_iter()
+                                    .flatten()
+                                    .collect();
+                                    for path in &mpv_paths {
+                                        if Command::new(path)
+                                            .arg("--")
+                                            .arg(stream_url)
+                                            .creation_flags(CREATE_BREAKAWAY_FROM_JOB)
+                                            .spawn()
+                                            .is_ok()
+                                        {
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    open::that(arg).ok();
+                                }
+                            }
+                        }
+                    }
                     Some("win-focus") => {
                         focus_sender.notice();
                     }


### PR DESCRIPTION
## Problem

When the user picks an external player from the WebUI's player menu, stremio-web emits a `play-external` IPC carrying a player-scheme URL. The Windows shell silently drops the message — the menu item appears to do nothing.

## Changes

Add a `play-external` IPC arm with a Windows-appropriate scheme allowlist (the macOS list — `iina`, `infuse`, `outplayer`, `open-vidhub` — has no Windows handlers and is intentionally not included):

- **Allowlist:** `mpv://`, `vlc://`, `potplayer://`. Anything else is silently dropped to prevent ShellExecute scheme abuse — the existing `open-external` arm exists for browser-style URLs and stays untouched.
- **`mpv://` is special:** mpv has no Windows URL handler, so we spawn the binary directly. `--` separates options from the stream URL so a malicious "stream URL" can't smuggle `--script=...` etc. as a flag. Common install paths are tried in order:
  - `%PROGRAMFILES%\mpv\mpv.exe`
  - `%PROGRAMFILES(X86)%\mpv\mpv.exe`
  - `%LOCALAPPDATA%\Programs\mpv\mpv.exe` (scoop's default)
  - `%LOCALAPPDATA%\mpv\mpv.exe`
  - bare `mpv.exe` (PATH lookup)
- Spawned with `CREATE_BREAKAWAY_FROM_JOB` so the streaming-server JobObject's `KILL_ON_JOB_CLOSE` doesn't kill mpv when the shell exits.
- `vlc://` and `potplayer://` are routed through `open::that` to use the OS protocol handler the user already has registered for them.

## Test

- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
