### PR TITLE
Pass streaming server URL to WebUI

### DIFF
--- a/src/stremio_app/app.rs
+++ b/src/stremio_app/app.rs
@@ -32,40 +32,6 @@ use crate::stremio_app::{
 
 use super::stremio_server::StremioServer;
 
-fn webui_url_with_streaming_server(webui_url: &str) -> String {
-    if webui_url.trim_end_matches('/') != WEB_ENDPOINT.trim_end_matches('/') {
-        return webui_url.to_string();
-    }
-
-    find_streaming_server_url()
-        .map(|server_url| web_endpoint_with_streaming_server(&server_url))
-        .unwrap_or_else(|| webui_url.to_string())
-}
-
-fn find_streaming_server_url() -> Option<String> {
-    let client = reqwest::blocking::Client::builder()
-        .timeout(time::Duration::from_millis(500))
-        .build()
-        .ok()?;
-
-    (11470..=11474).find_map(|port| {
-        let server_url = format!("http://127.0.0.1:{port}");
-        let settings_url = format!("{server_url}/settings");
-        let response = client.get(settings_url).send().ok()?;
-
-        if !response.status().is_success() {
-            return None;
-        }
-
-        let body = response.text().ok()?;
-        if body.contains("\"baseUrl\"") && body.contains("\"values\"") {
-            Some(server_url)
-        } else {
-            None
-        }
-    })
-}
-
 #[derive(Default, NwgUi)]
 pub struct MainWindow {
     pub command: String,
@@ -163,10 +129,16 @@ impl MainWindow {
         }
     }
     fn on_init(&self) {
-        self.webview
-            .endpoint
-            .set(webui_url_with_streaming_server(&self.webui_url))
-            .ok();
+        let webui_url =
+            if self.webui_url.trim_end_matches('/') == WEB_ENDPOINT.trim_end_matches('/') {
+                self.server
+                    .server_url()
+                    .map(|server_url| web_endpoint_with_streaming_server(&server_url))
+                    .unwrap_or_else(|| self.webui_url.clone())
+            } else {
+                self.webui_url.clone()
+            };
+        self.webview.endpoint.set(webui_url).ok();
         self.webview.dev_tools.set(self.dev_tools).ok();
         if let Some(hwnd) = self.window.handle.hwnd() {
             if let Ok(mut saved_style) = self.saved_window_style.try_borrow_mut() {

--- a/src/stremio_app/app.rs
+++ b/src/stremio_app/app.rs
@@ -16,7 +16,10 @@ use url::Url;
 use winapi::um::{winbase::CREATE_BREAKAWAY_FROM_JOB, winuser::WS_EX_TOPMOST};
 
 use crate::stremio_app::{
-    constants::{APP_NAME, UPDATE_ENDPOINT, UPDATE_INTERVAL, WINDOW_MIN_HEIGHT, WINDOW_MIN_WIDTH},
+    constants::{
+        web_endpoint_with_streaming_server, APP_NAME, UPDATE_ENDPOINT, UPDATE_INTERVAL,
+        WEB_ENDPOINT, WINDOW_MIN_HEIGHT, WINDOW_MIN_WIDTH,
+    },
     ipc::{RPCRequest, RPCResponse},
     splash::SplashImage,
     stremio_player::Player,
@@ -28,6 +31,40 @@ use crate::stremio_app::{
 };
 
 use super::stremio_server::StremioServer;
+
+fn webui_url_with_streaming_server(webui_url: &str) -> String {
+    if webui_url.trim_end_matches('/') != WEB_ENDPOINT.trim_end_matches('/') {
+        return webui_url.to_string();
+    }
+
+    find_streaming_server_url()
+        .map(|server_url| web_endpoint_with_streaming_server(&server_url))
+        .unwrap_or_else(|| webui_url.to_string())
+}
+
+fn find_streaming_server_url() -> Option<String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(time::Duration::from_millis(500))
+        .build()
+        .ok()?;
+
+    (11470..=11474).find_map(|port| {
+        let server_url = format!("http://127.0.0.1:{port}");
+        let settings_url = format!("{server_url}/settings");
+        let response = client.get(settings_url).send().ok()?;
+
+        if !response.status().is_success() {
+            return None;
+        }
+
+        let body = response.text().ok()?;
+        if body.contains("\"baseUrl\"") && body.contains("\"values\"") {
+            Some(server_url)
+        } else {
+            None
+        }
+    })
+}
 
 #[derive(Default, NwgUi)]
 pub struct MainWindow {
@@ -126,7 +163,10 @@ impl MainWindow {
         }
     }
     fn on_init(&self) {
-        self.webview.endpoint.set(self.webui_url.clone()).ok();
+        self.webview
+            .endpoint
+            .set(webui_url_with_streaming_server(&self.webui_url))
+            .ok();
         self.webview.dev_tools.set(self.dev_tools).ok();
         if let Some(hwnd) = self.window.handle.hwnd() {
             if let Ok(mut saved_style) = self.saved_window_style.try_borrow_mut() {

--- a/src/stremio_app/constants.rs
+++ b/src/stremio_app/constants.rs
@@ -15,3 +15,12 @@ pub const STREMIO_SERVER_DEV_MODE: &str = "STREMIO_SERVER_DEV_MODE";
 pub const SRV_BUFFER_SIZE: usize = 1024;
 pub const SERVER_IPC_KEY: &str = "SERVER_IPC_KEY";
 pub const SRV_LOG_SIZE: usize = 20;
+
+pub fn web_endpoint_with_streaming_server(server_url: &str) -> String {
+    let server_url = server_url.trim_end_matches('/');
+    let streaming_server_url =
+        url::form_urlencoded::byte_serialize(server_url.as_bytes()).collect::<String>();
+    let web_endpoint = WEB_ENDPOINT.trim_end_matches('/');
+
+    format!("{web_endpoint}/#/?streamingServerUrl={streaming_server_url}")
+}

--- a/src/stremio_app/stremio_server/server.rs
+++ b/src/stremio_app/stremio_server/server.rs
@@ -27,12 +27,17 @@ pub struct StremioServer {
     parent: nwg::ControlHandle,
     crash_notice: nwg::Notice,
     logs: Arc<Mutex<String>>,
+    server_url: Arc<Mutex<Option<String>>>,
 }
 
 impl StremioServer {
-    pub fn start(&self) {
+    pub fn server_url(&self) -> Option<String> {
+        self.server_url.lock().ok().and_then(|url| url.clone())
+    }
+
+    pub fn start(&self) -> Option<String> {
         if self.development {
-            return;
+            return None;
         }
         let (tx, rx) = flume::unbounded();
         let logs = self.logs.clone();
@@ -173,8 +178,12 @@ impl StremioServer {
             sender.notice();
         });
 
-        // Wait for the server to start
-        rx.recv().unwrap();
+        // Wait for the server to start and keep the exact endpoint printed by server.js.
+        let server_url = rx.recv().unwrap();
+        if let Ok(mut stored_url) = self.server_url.lock() {
+            *stored_url = Some(server_url.clone());
+        }
+        Some(server_url)
     }
 }
 
@@ -193,7 +202,7 @@ impl PartialUi for StremioServer {
             .parent(data.parent)
             .build(&mut data.crash_notice)
             .ok();
-        data.start();
+        let _ = data.start();
         println!("Stremio server started");
         Ok(())
     }
@@ -210,7 +219,7 @@ impl PartialUi for StremioServer {
                 "Stremio server crash log",
                 self.logs.lock().unwrap().deref(),
             );
-            self.start();
+            let _ = self.start();
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep loading WebUI from `https://web.stremio.com/` directly
- append `streamingServerUrl` in the initial WebUI hash route so core can consume the active server URL
- detect the active local server port across the existing 11470-11474 fallback range without touching the server/webview PR stacks
