### PR TITLE
Fix mpv reconnect on Real-Debrid 503s, JobObject leaks, server readiness detection

### DIFF
--- a/src/stremio_app/stremio_player/player.rs
+++ b/src/stremio_app/stremio_player/player.rs
@@ -176,6 +176,21 @@ fn create_mpv(window_handle: HWND) -> Mpv {
         set_property!("msg-level", "all=no");
         set_property!("quiet", "yes");
         set_property!("hwdec", "auto");
+        // Real-Debrid's proxy intermittently returns a transient HTTP 503
+        // (header "X-Error: read_pxy_timeout"), most often on seeks. ffmpeg's
+        // http protocol (used by mpv) has reconnection disabled by default,
+        // so it treats the 503 as a terminal error, reports EOF, and the web
+        // UI reads that as "video ended", incorrectly auto-advancing to the
+        // next episode or killing the stream. These mirror ffmpeg's own
+        // reconnect_* flags, enabling retry instead of aborting on transient
+        // HTTP failures. Note: stream-lavf-o splits sub-options on ",", so
+        // the literal "4xx,5xx" must use mpv's %N%string length-prefixed
+        // escape (%7% = length of "4xx,5xx") or the comma silently breaks
+        // the option and 5xx errors are dropped from the whitelist.
+        set_property!(
+            "stream-lavf-o",
+            "reconnect=1,reconnect_streamed=1,reconnect_on_http_error=%7%4xx,5xx,reconnect_delay_max=10"
+        );
         // gpu-next: libplacebo VO with modern HDR tone-mapping; gpu, is the fallback.
         set_property!("vo", "gpu-next,gpu,");
         for (name, value) in [

--- a/src/stremio_app/stremio_server/server.rs
+++ b/src/stremio_app/stremio_server/server.rs
@@ -12,6 +12,7 @@ use std::{
     thread,
 };
 use winapi::um::{
+    handleapi::CloseHandle,
     processthreadsapi::GetCurrentProcess,
     winbase::{CreateJobObjectA, CREATE_NO_WINDOW},
     winnt::{
@@ -48,25 +49,55 @@ impl StremioServer {
             // With the JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK and JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE flags
             unsafe {
                 let job_main_process = CreateJobObjectA(std::ptr::null_mut(), std::ptr::null_mut());
-                let jeli = JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
-                    BasicLimitInformation: JOBOBJECT_BASIC_LIMIT_INFORMATION {
-                        LimitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
-                            | JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
-                            | JOB_OBJECT_LIMIT_BREAKAWAY_OK,
+                if job_main_process.is_null() {
+                    eprintln!(
+                        "CreateJobObjectA failed: {}",
+                        std::io::Error::last_os_error()
+                    );
+                } else {
+                    let jeli = JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
+                        BasicLimitInformation: JOBOBJECT_BASIC_LIMIT_INFORMATION {
+                            LimitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+                                | JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
+                                | JOB_OBJECT_LIMIT_BREAKAWAY_OK,
+                            ..std::mem::zeroed()
+                        },
                         ..std::mem::zeroed()
-                    },
-                    ..std::mem::zeroed()
-                };
-                winapi::um::jobapi2::SetInformationJobObject(
-                    job_main_process,
-                    JobObjectExtendedLimitInformation,
-                    &jeli as *const _ as *mut _,
-                    std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
-                );
-                winapi::um::jobapi2::AssignProcessToJobObject(
-                    job_main_process,
-                    GetCurrentProcess(),
-                );
+                    };
+                    if winapi::um::jobapi2::SetInformationJobObject(
+                        job_main_process,
+                        JobObjectExtendedLimitInformation,
+                        &jeli as *const _ as *mut _,
+                        std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+                    ) == 0
+                    {
+                        eprintln!(
+                            "SetInformationJobObject failed: {}",
+                            std::io::Error::last_os_error()
+                        );
+                    }
+                    if winapi::um::jobapi2::AssignProcessToJobObject(
+                        job_main_process,
+                        GetCurrentProcess(),
+                    ) == 0
+                    {
+                        eprintln!(
+                            "AssignProcessToJobObject failed (parent likely already in a \
+                             non-breakaway job): {}",
+                            std::io::Error::last_os_error()
+                        );
+                        // Assignment failed, so this handle isn't backing a live
+                        // kill-on-close relationship with our process — close it
+                        // immediately instead of leaking it.
+                        CloseHandle(job_main_process);
+                    }
+                    // On success the handle intentionally stays open for the lifetime of
+                    // this process: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE fires when the last
+                    // handle to the job closes, and closing it here (right after our own
+                    // process was assigned to it) triggers that immediately. `start()` is
+                    // only called once at launch and again on the rare crash-restart path,
+                    // so this intentional per-call handle is bounded, not an unbounded leak.
+                }
             }
             let mut path = env::current_exe()
                 .and_then(fs::canonicalize)
@@ -87,7 +118,12 @@ impl StremioServer {
                     let out_lines = lines.clone();
                     let tx = tx.clone();
                     let out_thread = thread::spawn(move || {
-                        let http_endpoint = String::new();
+                        let mut endpoint_sent = false;
+                        // Accumulates output across reads so the readiness line is still
+                        // found if "EngineFS server started at ..." straddles a read
+                        // boundary; without this, a chunk split mid-line means neither
+                        // read contains the full line and readiness is silently missed.
+                        let mut pending = String::new();
                         loop {
                             let mut buffer = [0; SRV_BUFFER_SIZE];
                             let on = match stdout.read(&mut buffer[..]) {
@@ -103,16 +139,22 @@ impl StremioServer {
                             {
                                 let lines = &mut *out_lines.lock().unwrap();
                                 *lines += string_data.deref();
-                                if http_endpoint.is_empty() {
-                                    if let Some(http_endpoint) = string_data
-                                        .lines()
-                                        .find(|line| line.starts_with("EngineFS server started at"))
-                                    {
-                                        let http_endpoint =
-                                            http_endpoint.split_whitespace().last().unwrap();
-                                        println!("HTTP endpoint: {http_endpoint}");
-                                        let endpoint = http_endpoint.to_string();
-                                        tx.send(endpoint.clone()).ok();
+                                if !endpoint_sent {
+                                    pending += string_data.deref();
+                                    if let Some(line_end) = pending.rfind('\n') {
+                                        let (complete, rest) = pending.split_at(line_end + 1);
+                                        if let Some(http_endpoint) = complete
+                                            .lines()
+                                            .find(|line| {
+                                                line.starts_with("EngineFS server started at")
+                                            })
+                                            .and_then(|line| line.split_whitespace().last())
+                                        {
+                                            println!("HTTP endpoint: {http_endpoint}");
+                                            tx.send(http_endpoint.to_string()).ok();
+                                            endpoint_sent = true;
+                                        }
+                                        pending = rest.to_string();
                                     }
                                 }
                                 *lines = lines

--- a/upload.ps1
+++ b/upload.ps1
@@ -1,4 +1,4 @@
-$tag = $(git describe --tags --abbrev=0)
+$tag = $(git describe --abbrev=0)
 
 foreach ($installer in (get-item .\StremioSetup*.exe)) {
     if ($tag.StartsWith("v$($installer.VersionInfo.ProductVersion.Trim())")) {


### PR DESCRIPTION
Fixes streams randomly dying or auto-skipping to the next episode mid-playback, plus three smaller things already flagged in issues here.

## Main fix: mpv reconnect on transient HTTP errors

Real-Debrid's proxy occasionally throws a transient HTTP 503 (`X-Error: read_pxy_timeout`), mostly when seeking. mpv's http backend (ffmpeg) doesn't retry on http errors by default, so it just reports end-of-file - and the WebUI treats that exactly like the video ending, so it either auto-advances to the next episode or the stream just dies. VLC hitting the same URL recovers on its own, which is what pointed at this in the first place - compared logs from both against the same failing URL.

Fix is enabling ffmpeg's own reconnect options (`reconnect`, `reconnect_streamed`, `reconnect_on_http_error`, `reconnect_delay_max`) on the mpv stream. Tested across several titles/resolutions and the 503s that used to kill playback now just retry silently.

One gotcha worth calling out: `stream-lavf-o` splits its sub-options on `,`, so a literal `4xx,5xx` in `reconnect_on_http_error` needs mpv's `%N%string` length-prefixed escape or it silently gets truncated to just `4xx`.

## Three smaller fixes (server.rs)

- Return values from `SetInformationJobObject`/`AssignProcessToJobObject` were never checked, so a failure there (e.g. on a restricted job config) went unnoticed - #47
- The JobObject handle was never closed, leaking one per server start/crash-restart - #48
- Readiness-line detection only checked whatever came back from a single `read()` call; if `EngineFS server started at ...` landed split across two reads, it never matched and you'd sit on the 60s timeout for nothing - #53
