### PR TITLE
Fix Rust 1.97 Clippy build

### DIFF
--- a/src/stremio_app/stremio_player/player.rs
+++ b/src/stremio_app/stremio_player/player.rs
@@ -506,7 +506,7 @@ fn create_message_thread(
             let in_msg: InMsg = match serde_json::from_str(&msg) {
                 Ok(in_msg) => in_msg,
                 Err(error) => {
-                    eprintln!("cannot parse InMsg:{:?} {error:#}", &msg);
+                    eprintln!("cannot parse InMsg:{:?} {error:#}", msg);
                     continue;
                 }
             };

--- a/src/stremio_app/stremio_server/server.rs
+++ b/src/stremio_app/stremio_server/server.rs
@@ -165,7 +165,7 @@ impl StremioServer {
                 Err(err) => {
                     nwg::error_message(
                         "Stremio server",
-                        format!("Cannot execute stremio-runtime: {}", &err).as_str(),
+                        format!("Cannot execute stremio-runtime: {}", err).as_str(),
                     );
                 }
             };

--- a/src/stremio_app/updater.rs
+++ b/src/stremio_app/updater.rs
@@ -61,7 +61,7 @@ impl Updater {
     pub fn autoupdate(&self) -> Result<Option<Update>, anyhow::Error> {
         // Check for updates
         println!("Fetching updates for v{}", self.current_version);
-        println!("Using updater endpoint {}", &self.endpoint);
+        println!("Using updater endpoint {}", self.endpoint);
         let update_response =
             reqwest::blocking::get(self.endpoint.clone())?.json::<UpdateResponse>()?;
         let update_descriptor =


### PR DESCRIPTION
Remove three redundant formatting borrows rejected by the Clippy version bundled with Rust 1.97.