### PR TITLE
Update libmpv2 to 6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,9 +895,9 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libmpv2"
-version = "5.0.3"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88dc8432d3de09ed6e343488d6b208467db6801fb41971a1f726fa2248302fe5"
+checksum = "3f3d44c1c29b866d44453249d1d8b2822d891fdabd08359a5b85bb6944445e70"
 dependencies = [
  "libmpv2-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ winapi = { version = "0.3.9", features = [
 ] }
 webview2 = "0.1.4"
 webview2-sys = "0.1.1"
-libmpv2 = "5.0.3"
+libmpv2 = "6.0.0"
 libmpv2-sys = "4.0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/stremio_app/stremio_player/player.rs
+++ b/src/stremio_app/stremio_player/player.rs
@@ -416,7 +416,7 @@ fn display_hdr_active(path: &DISPLAYCONFIG_PATH_INFO) -> Option<bool> {
 }
 
 fn create_event_thread(
-    mut mpv_event_client: Mpv,
+    mpv_event_client: Mpv,
     observe_property_receiver: Receiver<ObserveProperty>,
     rpc_response_sender: Sender<String>,
 ) -> JoinHandle<()> {


### PR DESCRIPTION
Updates the published libmpv2 crate from 5.0.3 to 6.0.0. libmpv2-sys remains on 4.0.1.