### PR TITLE
Add focused native Picture-in-Picture support

### DIFF
--- a/src/stremio_app/app.rs
+++ b/src/stremio_app/app.rs
@@ -3,7 +3,7 @@ use native_windows_gui as nwg;
 use rand::Rng;
 use serde_json;
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     io::Read,
     os::windows::process::CommandExt,
     path::{Path, PathBuf},
@@ -13,6 +13,7 @@ use std::{
     thread, time,
 };
 use url::Url;
+use winapi::shared::windef::HWND;
 use winapi::um::{winbase::CREATE_BREAKAWAY_FROM_JOB, winuser::WS_EX_TOPMOST};
 
 use crate::stremio_app::{
@@ -21,13 +22,15 @@ use crate::stremio_app::{
         WEB_ENDPOINT, WINDOW_MIN_HEIGHT, WINDOW_MIN_WIDTH,
     },
     ipc::{RPCRequest, RPCResponse},
+    mpv_hwnd::find_mpv_child_hwnd,
+    pip_window::PipWindow,
     splash::SplashImage,
     stremio_player::Player,
     stremio_wevbiew::WebView,
     systray::SystemTray,
     updater,
     window_helper::WindowStyle,
-    window_settings::WindowSettings,
+    window_settings::{PipPlacement, WindowSettings},
     PipeServer,
 };
 
@@ -47,6 +50,10 @@ pub struct MainWindow {
     pub release_candidate: bool,
     pub autoupdater_setup_file: Arc<Mutex<Option<PathBuf>>>,
     pub requested_fullscreen: Arc<Mutex<Option<bool>>>,
+    pub requested_pip: Arc<Mutex<Option<bool>>>,
+    pub pip_window: RefCell<PipWindow>,
+    pub pip_active: Cell<bool>,
+    pub mpv_child_hwnd: Cell<Option<HWND>>,
     pub saved_window_style: RefCell<WindowStyle>,
     #[nwg_resource]
     pub embed: nwg::EmbedResource,
@@ -70,6 +77,7 @@ pub struct MainWindow {
         (tray_exit, OnMenuItemSelected): [Self::on_exit],
         (tray_show_hide, OnMenuItemSelected): [Self::on_show_hide],
         (tray_topmost, OnMenuItemSelected): [Self::on_toggle_topmost],
+        (tray_pip, OnMenuItemSelected): [Self::on_tray_toggle_pip],
     )]
     pub tray: SystemTray,
     #[nwg_partial(parent: window)]
@@ -83,6 +91,9 @@ pub struct MainWindow {
     #[nwg_control]
     #[nwg_events(OnNotice: [Self::on_toggle_fullscreen_notice] )]
     pub toggle_fullscreen_notice: nwg::Notice,
+    #[nwg_control]
+    #[nwg_events(OnNotice: [Self::on_toggle_pip_notice] )]
+    pub toggle_pip_notice: nwg::Notice,
     #[nwg_control]
     #[nwg_events(OnNotice: [nwg::stop_thread_dispatch()] )]
     pub quit_notice: nwg::Notice,
@@ -160,6 +171,21 @@ impl MainWindow {
         self.tray.tray_show_hide.set_checked(!self.start_hidden);
         if self.no_splash {
             self.splash_screen.hide();
+        }
+
+        let pip_placement = PipPlacement::load();
+        if let Ok(mut pip) = self.pip_window.try_borrow_mut() {
+            if let Err(error) = pip.build(
+                self.toggle_pip_notice.sender(),
+                pip_placement
+                    .as_ref()
+                    .map(|placement| (placement.x, placement.y)),
+                pip_placement
+                    .as_ref()
+                    .map(|placement| (placement.width, placement.height)),
+            ) {
+                eprintln!("Failed to build PiP window: {error:?}");
+            }
         }
 
         let player_channel = self.player.channel.borrow();
@@ -265,6 +291,7 @@ impl MainWindow {
         }); // thread
 
         let toggle_fullscreen_sender = self.toggle_fullscreen_notice.sender();
+        let toggle_pip_sender = self.toggle_pip_notice.sender();
         let quit_sender = self.quit_notice.sender();
         let hide_splash_sender = self.hide_splash_notice.sender();
         let focus_sender = self.focus_notice.sender();
@@ -272,6 +299,7 @@ impl MainWindow {
 
         let discord_rpc = DiscordRpc::new(web_tx.clone());
         let requested_fullscreen = self.requested_fullscreen.clone();
+        let requested_pip = self.requested_pip.clone();
 
         thread::spawn(move || loop {
             if let Some(msg) = web_rx
@@ -293,6 +321,14 @@ impl MainWindow {
                             *requested_fullscreen.lock().unwrap() = Some(fullscreen);
                             toggle_fullscreen_sender.notice();
                         }
+                    }
+                    Some("win-set-pip") => {
+                        let enabled = msg
+                            .get_params()
+                            .and_then(|params| params.get("enabled"))
+                            .and_then(|value| value.as_bool());
+                        *requested_pip.lock().unwrap() = enabled;
+                        toggle_pip_sender.notice();
                     }
                     Some("quit") => quit_sender.notice(),
                     Some("app-ready") => {
@@ -502,14 +538,24 @@ impl MainWindow {
         }
     }
     fn on_toggle_fullscreen_notice(&self) {
+        let currently_fullscreen = self
+            .saved_window_style
+            .try_borrow()
+            .map(|style| style.full_screen)
+            .unwrap_or(false);
+        let target = self
+            .requested_fullscreen
+            .lock()
+            .unwrap()
+            .take()
+            .unwrap_or(!currently_fullscreen);
+        if target && self.pip_active.get() {
+            *self.requested_pip.lock().unwrap() = Some(false);
+            self.on_toggle_pip_notice();
+        }
+
         if let Some(hwnd) = self.window.handle.hwnd() {
             if let Ok(mut saved_style) = self.saved_window_style.try_borrow_mut() {
-                let target = self
-                    .requested_fullscreen
-                    .lock()
-                    .unwrap()
-                    .take()
-                    .unwrap_or(!saved_style.full_screen);
                 saved_style.set_full_screen(hwnd, target);
                 self.tray.tray_topmost.set_enabled(!saved_style.full_screen);
                 self.tray
@@ -518,6 +564,72 @@ impl MainWindow {
             }
         }
         self.transmit_window_visibility_change();
+    }
+    fn transmit_pip_change(&self, enabled: bool) {
+        if let Ok(web_channel) = self.webview.channel.try_borrow() {
+            if let Some((web_tx, _)) = web_channel.as_ref() {
+                web_tx.send(RPCResponse::pip_change(enabled)).ok();
+            }
+        }
+    }
+    fn on_tray_toggle_pip(&self) {
+        *self.requested_pip.lock().unwrap() = None;
+        self.toggle_pip_notice.sender().notice();
+    }
+    fn on_toggle_pip_notice(&self) {
+        let Some(main_hwnd) = self.window.handle.hwnd() else {
+            return;
+        };
+        let requested = self.requested_pip.lock().unwrap().take();
+        let target = requested.unwrap_or(!self.pip_active.get());
+
+        if target == self.pip_active.get() {
+            return;
+        }
+        if target
+            && self
+                .saved_window_style
+                .try_borrow()
+                .map(|style| style.full_screen)
+                .unwrap_or(false)
+        {
+            return;
+        }
+
+        let Ok(pip) = self.pip_window.try_borrow() else {
+            return;
+        };
+        if !pip.built.get() {
+            return;
+        }
+
+        if target {
+            let Some(child) = self
+                .mpv_child_hwnd
+                .get()
+                .or_else(|| find_mpv_child_hwnd(main_hwnd))
+            else {
+                eprintln!("PiP enable: MPV child window not found");
+                return;
+            };
+            if !pip.attach_video(child) {
+                eprintln!("PiP enable: failed to attach MPV child window");
+                return;
+            }
+            self.mpv_child_hwnd.set(Some(child));
+            pip.show();
+        } else {
+            if let Some(placement) = pip.current_placement() {
+                PipPlacement::save(placement).ok();
+            }
+            pip.detach_video(main_hwnd);
+            pip.hide();
+            self.webview.fit_to_window(Some(main_hwnd));
+        }
+
+        self.pip_active.set(target);
+        self.tray.tray_pip.set_checked(target);
+        self.transmit_pip_change(target);
     }
     fn on_hide_splash_notice(&self) {
         self.splash_screen.hide();
@@ -570,12 +682,30 @@ impl MainWindow {
             data.close(false);
         }
         self.save_window_settings();
+        self.cleanup_pip_for_exit();
         self.window.set_visible(false);
         self.tray.tray_show_hide.set_checked(self.window.visible());
         self.transmit_window_visibility_change();
     }
     fn on_exit(&self) {
         self.save_window_settings();
+        self.cleanup_pip_for_exit();
         nwg::stop_thread_dispatch();
+    }
+    fn cleanup_pip_for_exit(&self) {
+        if !self.pip_active.get() {
+            return;
+        }
+        let Some(main_hwnd) = self.window.handle.hwnd() else {
+            return;
+        };
+        if let Ok(pip) = self.pip_window.try_borrow() {
+            if let Some(placement) = pip.current_placement() {
+                PipPlacement::save(placement).ok();
+            }
+            pip.detach_video(main_hwnd);
+            pip.hide();
+        }
+        self.pip_active.set(false);
     }
 }

--- a/src/stremio_app/ipc.rs
+++ b/src/stremio_app/ipc.rs
@@ -121,4 +121,9 @@ impl RPCResponse {
     pub fn media_key(action: &str) -> String {
         Self::response_message(Some(json!(["media-key", action])))
     }
+    pub fn pip_change(enabled: bool) -> String {
+        Self::response_message(Some(json!(["win-pip-changed", {
+            "enabled": enabled,
+        }])))
+    }
 }

--- a/src/stremio_app/mod.rs
+++ b/src/stremio_app/mod.rs
@@ -3,6 +3,8 @@ pub use app::MainWindow;
 pub mod discord;
 pub mod gpu_video_processing;
 pub mod ipc;
+pub mod mpv_hwnd;
+pub mod pip_window;
 pub mod stremio_player;
 pub mod stremio_server;
 pub mod stremio_wevbiew;

--- a/src/stremio_app/mpv_hwnd.rs
+++ b/src/stremio_app/mpv_hwnd.rs
@@ -1,0 +1,42 @@
+use winapi::shared::minwindef::{BOOL, LPARAM, TRUE};
+use winapi::shared::windef::HWND;
+use winapi::um::winuser::{EnumChildWindows, GetClassNameA};
+
+struct EnumState {
+    found: Option<HWND>,
+}
+
+fn class_name(hwnd: HWND) -> String {
+    let mut buffer = [0i8; 256];
+    let length = unsafe { GetClassNameA(hwnd, buffer.as_mut_ptr(), buffer.len() as i32) };
+    if length <= 0 {
+        return String::new();
+    }
+    let bytes = buffer[..length as usize]
+        .iter()
+        .map(|value| *value as u8)
+        .collect::<Vec<_>>();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+unsafe extern "system" fn enum_proc(hwnd: HWND, lparam: LPARAM) -> BOOL {
+    let state = &mut *(lparam as *mut EnumState);
+    if class_name(hwnd).eq_ignore_ascii_case("mpv") {
+        state.found = Some(hwnd);
+        return 0;
+    }
+    TRUE
+}
+
+/// Find MPV's own child window without guessing at unrelated WebView children.
+pub fn find_mpv_child_hwnd(parent: HWND) -> Option<HWND> {
+    let mut state = EnumState { found: None };
+    unsafe {
+        EnumChildWindows(
+            parent,
+            Some(enum_proc),
+            &mut state as *mut EnumState as LPARAM,
+        );
+    }
+    state.found
+}

--- a/src/stremio_app/pip_window.rs
+++ b/src/stremio_app/pip_window.rs
@@ -1,0 +1,174 @@
+use native_windows_gui as nwg;
+use std::{cell::Cell, rc::Rc};
+use winapi::shared::windef::{HWND, RECT};
+use winapi::um::winuser::{
+    GetClientRect, GetWindowLongA, GetWindowRect, MoveWindow, SetParent, SetWindowLongA,
+    SetWindowPos, GWL_STYLE, HWND_TOP, HWND_TOPMOST, SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE,
+    SWP_NOSIZE, SWP_SHOWWINDOW, WM_CLOSE, WM_SIZE, WS_CHILD, WS_EX_TOPMOST, WS_POPUP,
+};
+
+use crate::stremio_app::window_settings::PipPlacement;
+
+/// Native PiP host for the MPV child window.
+///
+/// The Web UI owns the PiP control. This type only owns the native window and
+/// temporarily reparents MPV into it, keeping the shell implementation small.
+#[derive(Default)]
+pub struct PipWindow {
+    pub window: nwg::Window,
+    pub built: Cell<bool>,
+    mpv_child: Rc<Cell<Option<HWND>>>,
+    original_mpv_style: Rc<Cell<Option<i32>>>,
+}
+
+impl PipWindow {
+    pub fn build(
+        &mut self,
+        close_sender: nwg::NoticeSender,
+        initial_pos: Option<(i32, i32)>,
+        initial_size: Option<(i32, i32)>,
+    ) -> Result<(), nwg::NwgError> {
+        if self.built.get() {
+            return Ok(());
+        }
+
+        let (width, height) = initial_size.unwrap_or((640, 360));
+        let mut builder = nwg::Window::builder()
+            .title("Stremio - Picture-in-Picture")
+            .size((width.max(320), height.max(180)))
+            .flags(
+                nwg::WindowFlags::WINDOW
+                    | nwg::WindowFlags::RESIZABLE
+                    | nwg::WindowFlags::MINIMIZE_BOX,
+            )
+            .ex_flags(WS_EX_TOPMOST);
+        if let Some((x, y)) = initial_pos {
+            builder = builder.position((x, y));
+        }
+        builder.build(&mut self.window)?;
+
+        // Closing the PiP window is equivalent to pressing the web UI's exit
+        // control. The main window performs the reparenting on its UI thread.
+        let mpv_child = self.mpv_child.clone();
+        nwg::bind_raw_event_handler(&self.window.handle, 0x10002, move |hwnd, msg, _w, _l| {
+            match msg {
+                WM_CLOSE => {
+                    close_sender.notice();
+                    return Some(0);
+                }
+                WM_SIZE => {
+                    if let Some(child) = mpv_child.get() {
+                        unsafe { resize_child_to_parent(child, hwnd) };
+                    }
+                }
+                _ => {}
+            }
+            None
+        })
+        .ok();
+
+        self.built.set(true);
+        self.window.set_visible(false);
+        Ok(())
+    }
+
+    pub fn show(&self) {
+        self.window.set_visible(true);
+    }
+
+    pub fn hide(&self) {
+        self.window.set_visible(false);
+    }
+
+    pub fn attach_video(&self, child: HWND) -> bool {
+        let Some(target) = self.window.handle.hwnd() else {
+            return false;
+        };
+
+        unsafe {
+            let style = GetWindowLongA(child, GWL_STYLE);
+            self.original_mpv_style.set(Some(style));
+            SetParent(child, target);
+            SetWindowLongA(
+                child,
+                GWL_STYLE,
+                (style | WS_CHILD as i32) & !(WS_POPUP as i32),
+            );
+            resize_child_to_parent(child, target);
+            SetWindowPos(
+                child,
+                HWND_TOP,
+                0,
+                0,
+                0,
+                0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW,
+            );
+            SetWindowPos(
+                target,
+                HWND_TOPMOST,
+                0,
+                0,
+                0,
+                0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_FRAMECHANGED,
+            );
+        }
+        self.mpv_child.set(Some(child));
+        true
+    }
+
+    pub fn detach_video(&self, target: HWND) {
+        let Some(child) = self.mpv_child.take() else {
+            return;
+        };
+
+        unsafe {
+            SetParent(child, target);
+            if let Some(style) = self.original_mpv_style.take() {
+                SetWindowLongA(child, GWL_STYLE, style);
+            }
+            resize_child_to_parent(child, target);
+            SetWindowPos(
+                child,
+                HWND_TOP,
+                0,
+                0,
+                0,
+                0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW,
+            );
+        }
+    }
+
+    pub fn current_placement(&self) -> Option<PipPlacement> {
+        let hwnd = self.window.handle.hwnd()?;
+        unsafe {
+            let mut rect: RECT = std::mem::zeroed();
+            if GetWindowRect(hwnd, &mut rect) == 0 {
+                return None;
+            }
+            Some(PipPlacement {
+                x: rect.left,
+                y: rect.top,
+                width: (rect.right - rect.left).max(320),
+                height: (rect.bottom - rect.top).max(180),
+                transparent: false,
+            })
+        }
+    }
+}
+
+unsafe fn resize_child_to_parent(child: HWND, parent: HWND) {
+    let mut rect: RECT = std::mem::zeroed();
+    if GetClientRect(parent, &mut rect) != 0 {
+        MoveWindow(
+            child,
+            0,
+            0,
+            (rect.right - rect.left).max(1),
+            (rect.bottom - rect.top).max(1),
+            1,
+        );
+    }
+}

--- a/src/stremio_app/systray.rs
+++ b/src/stremio_app/systray.rs
@@ -16,6 +16,8 @@ pub struct SystemTray {
     pub tray_show_hide: nwg::MenuItem,
     #[nwg_control(parent: tray_menu, text: "Always on &top")]
     pub tray_topmost: nwg::MenuItem,
+    #[nwg_control(parent: tray_menu, text: "Picture-in-&Picture")]
+    pub tray_pip: nwg::MenuItem,
     #[nwg_control(parent: tray_menu, text: "&Quit")]
     pub tray_exit: nwg::MenuItem,
 }

--- a/src/stremio_app/window_settings.rs
+++ b/src/stremio_app/window_settings.rs
@@ -6,6 +6,7 @@ use winapi::um::winuser::{
 };
 
 const WINDOW_SETTINGS_FILE: &str = "window-state.json";
+const PIP_SETTINGS_FILE: &str = "pip-state.json";
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct WindowSettings {
@@ -13,6 +14,33 @@ pub struct WindowSettings {
     min_position: Point,
     max_position: Point,
     normal_position: Rect,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PipPlacement {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+    #[serde(default)]
+    pub transparent: bool,
+}
+
+impl PipPlacement {
+    pub fn load() -> Option<Self> {
+        fs::read_to_string(pip_settings_path())
+            .ok()
+            .and_then(|settings| serde_json::from_str(&settings).ok())
+    }
+
+    pub fn save(placement: Self) -> io::Result<()> {
+        let path = pip_settings_path();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(&placement).map_err(io::Error::other)?;
+        fs::write(path, json)
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -108,6 +136,14 @@ fn settings_path() -> PathBuf {
         .unwrap_or_else(env::temp_dir)
         .join("Stremio")
         .join(WINDOW_SETTINGS_FILE)
+}
+
+fn pip_settings_path() -> PathBuf {
+    env::var_os("APPDATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(env::temp_dir)
+        .join("Stremio")
+        .join(PIP_SETTINGS_FILE)
 }
 
 fn is_restorable_size(rect: &RECT) -> bool {


### PR DESCRIPTION
## Summary
- handle the `win-set-pip` / `win-pip-changed` IPC used by stremio-web#1354
- reparent the existing MPV child into a resizable, always-on-top native window
- resize MPV with the PiP window and restore it safely when PiP closes
- persist the PiP window placement
- add a tray toggle as a fallback control

## Review notes
This is a focused replacement for [#78](https://github.com/Stremio/stremio-shell-ng/pull/78). It keeps PiP shell-side, removes the duplicated web-control injection, avoids a custom GDI+ overlay, and does not guess at unrelated child windows when locating MPV. The web control remains owned by [stremio-web#1354](https://github.com/Stremio/stremio-web/pull/1354).

## Validation
- `cargo fmt --all -- --check`
- `cargo check --target x86_64-pc-windows-msvc` (passed; the macOS host required skipping only the Windows resource compiler step)
- `git diff --check` with the repository's CRLF files handled