### PR TITLE
Restore play-external for VLC and M3U playlists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,6 +1702,7 @@ dependencies = [
  "webview2-sys",
  "whoami",
  "winapi",
+ "winreg",
  "winres",
  "zip-extract",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "discord-rich-presence"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +930,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb32cabe7176b7d270b0dca6ff418b75187ae8d3854423e3d06fbff376841e4"
 
 [[package]]
+name = "libredox"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libz-rs-sys"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1176,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parse-display"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,6 +1366,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.12",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1627,9 +1674,11 @@ name = "stremio-shell-ng"
 version = "5.0.25"
 dependencies = [
  "anyhow",
+ "base64",
  "bitflags 2.4.2",
  "chrono",
  "clap",
+ "dirs",
  "discord-rich-presence",
  "flume",
  "libmpv2",
@@ -2225,6 +2274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,6 +2295,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1.19", features = ["v4"]}
 base64 = "0.22"
 dirs = "6"
+winreg = "0.52"
 
 [build-dependencies]
 winres = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ reqwest = { version = "0.12", features = ["stream", "json", "blocking"] }
 rand = "0.8"
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1.19", features = ["v4"]}
+base64 = "0.22"
+dirs = "6"
 
 [build-dependencies]
 winres = "0.1"

--- a/src/stremio_app/app.rs
+++ b/src/stremio_app/app.rs
@@ -335,53 +335,13 @@ impl MainWindow {
                             }
                         }
                     }
-                    // play-external is temporary disabled due to security concerns
-                    // Some("play-external") => {
-                    //     if let Some(arg) = msg.get_params() {
-                    //         let arg = arg.as_str().unwrap_or("");
-                    //         let arg_lc = arg.to_lowercase();
-                    //         const ALLOWED_SCHEMES: &[&str] = &["mpv://", "vlc://", "potplayer://"];
-                    //         let allowed = ALLOWED_SCHEMES.iter().any(|s| arg_lc.starts_with(s));
-                    //         if !arg.is_empty() && allowed {
-                    //             if let Some(stream_url) =
-                    //                 arg_lc.starts_with("mpv://").then(|| &arg[6..])
-                    //             {
-                    //                 // `--` ends mpv's option parsing; the stream URL can't smuggle flags.
-                    //                 let mpv_paths: Vec<String> = vec![
-                    //                     std::env::var("ProgramFiles")
-                    //                         .ok()
-                    //                         .map(|v| format!("{v}\\mpv\\mpv.exe")),
-                    //                     std::env::var("ProgramFiles(x86)")
-                    //                         .ok()
-                    //                         .map(|v| format!("{v}\\mpv\\mpv.exe")),
-                    //                     std::env::var("LOCALAPPDATA")
-                    //                         .ok()
-                    //                         .map(|v| format!("{v}\\Programs\\mpv\\mpv.exe")),
-                    //                     std::env::var("LOCALAPPDATA")
-                    //                         .ok()
-                    //                         .map(|v| format!("{v}\\mpv\\mpv.exe")),
-                    //                     Some("mpv.exe".to_string()),
-                    //                 ]
-                    //                 .into_iter()
-                    //                 .flatten()
-                    //                 .collect();
-                    //                 for path in &mpv_paths {
-                    //                     if Command::new(path)
-                    //                         .arg("--")
-                    //                         .arg(stream_url)
-                    //                         .creation_flags(CREATE_BREAKAWAY_FROM_JOB)
-                    //                         .spawn()
-                    //                         .is_ok()
-                    //                     {
-                    //                         break;
-                    //                     }
-                    //                 }
-                    //             } else {
-                    //                 open::that(arg).ok();
-                    //             }
-                    //         }
-                    //     }
-                    // }
+                    Some("play-external") => {
+                        if let Some(arg) = msg.get_params().and_then(|value| value.as_str()) {
+                            if let Err(error) = crate::stremio_app::external_player::play(arg) {
+                                eprintln!("External player request failed: {error}");
+                            }
+                        }
+                    }
                     Some("win-focus") => {
                         focus_sender.notice();
                     }

--- a/src/stremio_app/external_player.rs
+++ b/src/stremio_app/external_player.rs
@@ -1,19 +1,135 @@
-use std::{ffi::OsString, fs, os::windows::process::CommandExt, process::Command};
+use std::{
+    env, ffi::OsString, fs, os::windows::process::CommandExt, path::PathBuf, process::Command,
+};
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use native_windows_gui as nwg;
 use url::Url;
 use winapi::um::winbase::{CREATE_BREAKAWAY_FROM_JOB, CREATE_NO_WINDOW};
+use winreg::{
+    enums::{HKEY_CLASSES_ROOT, HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE},
+    RegKey,
+};
+
+use crate::stremio_app::constants::APP_NAME;
 
 const M3U_DATA_URI_PREFIX: &str = "data:application/octet-stream;charset=utf-8;base64,";
+const APP_PATHS: &str = r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths";
+
+#[derive(Debug, PartialEq)]
+enum Request {
+    Vlc(Url),
+    Playlist(Url),
+}
 
 pub fn play(input: &str) -> Result<(), &'static str> {
-    let stream_url = parse_playlist(input)?;
+    match parse(input)? {
+        Request::Vlc(url) => spawn_player("VLC", "vlc.exe", r"VideoLAN\VLC\vlc.exe", &url),
+        Request::Playlist(url) => open_playlist(&url),
+    }
+}
+
+fn parse(input: &str) -> Result<Request, &'static str> {
+    if let Some(encoded) = input.strip_prefix(M3U_DATA_URI_PREFIX) {
+        return parse_playlist(encoded).map(Request::Playlist);
+    }
+    let (scheme, rest) = input
+        .split_once("://")
+        .ok_or("unsupported external player")?;
+    match scheme.to_ascii_lowercase().as_str() {
+        "vlc" => stream_url(rest).map(Request::Vlc),
+        _ => Err("unsupported external player"),
+    }
+}
+
+fn parse_playlist(encoded: &str) -> Result<Url, &'static str> {
+    let decoded = BASE64.decode(encoded).map_err(|_| "invalid playlist")?;
+    let playlist = String::from_utf8(decoded).map_err(|_| "invalid playlist")?;
+    let mut lines = playlist.lines();
+    if lines.next() != Some("#EXTM3U") || lines.next() != Some("#EXTINF:0") {
+        return Err("invalid playlist");
+    }
+    let url = lines.next().ok_or("invalid playlist")?;
+    if lines.next().is_some() {
+        return Err("invalid playlist");
+    }
+    stream_url(url)
+}
+
+fn stream_url(input: &str) -> Result<Url, &'static str> {
+    const ERROR: &str = "stream URL must be absolute HTTP(S)";
+    if input.bytes().any(|byte| byte.is_ascii_whitespace()) {
+        return Err(ERROR);
+    }
+    let url = Url::parse(input).map_err(|_| ERROR)?;
+    if !matches!(url.scheme(), "http" | "https") || url.host().is_none() {
+        return Err(ERROR);
+    }
+    Ok(url)
+}
+
+fn spawn_player(name: &str, exe: &str, install_path: &str, url: &Url) -> Result<(), &'static str> {
+    let paths = player_paths(exe, install_path);
+    let spawned = paths.iter().find_map(|path| {
+        Command::new(path)
+            .arg("--")
+            .arg(url.as_str())
+            .creation_flags(CREATE_BREAKAWAY_FROM_JOB)
+            .spawn()
+            .ok()
+    });
+    if spawned.is_none() {
+        eprintln!("{name} was not found in {paths:?}");
+        nwg::error_message(
+            APP_NAME,
+            &format!("{name} was not found on this computer. Install it and try again."),
+        );
+        return Err("external player is not installed");
+    }
+    Ok(())
+}
+
+fn player_paths(exe: &str, install_path: &str) -> Vec<PathBuf> {
+    let app_paths = [HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE]
+        .iter()
+        .filter_map(|hive| {
+            RegKey::predef(*hive)
+                .open_subkey(format!(r"{APP_PATHS}\{exe}"))
+                .and_then(|key| key.get_value::<String, _>(""))
+                .ok()
+        })
+        .map(|path| PathBuf::from(path.trim_matches('"')));
+    let open_with = RegKey::predef(HKEY_CLASSES_ROOT)
+        .open_subkey(format!(r"Applications\{exe}\shell\open\command"))
+        .and_then(|key| key.get_value::<String, _>(""))
+        .ok()
+        .and_then(|command| command_program(&command));
+    let default_dirs = ["ProgramFiles", "ProgramFiles(x86)"]
+        .iter()
+        .filter_map(env::var_os)
+        .map(|dir| PathBuf::from(dir).join(install_path));
+    app_paths
+        .chain(open_with)
+        .chain(default_dirs)
+        .chain([PathBuf::from(exe)])
+        .collect()
+}
+
+fn command_program(command: &str) -> Option<PathBuf> {
+    let program = match command.strip_prefix('"') {
+        Some(quoted) => quoted.split('"').next()?,
+        None => command.split(' ').next()?,
+    };
+    (!program.is_empty()).then(|| PathBuf::from(program))
+}
+
+fn open_playlist(url: &Url) -> Result<(), &'static str> {
     let directory = dirs::download_dir()
         .ok_or("Downloads directory is unavailable")?
         .join("Stremio");
     fs::create_dir_all(&directory).map_err(|_| "cannot create playlist directory")?;
     let path = directory.join("playlist.m3u");
-    fs::write(&path, format!("#EXTM3U\n#EXTINF:0\n{stream_url}"))
+    fs::write(&path, format!("#EXTM3U\n#EXTINF:0\n{url}"))
         .map_err(|_| "cannot save M3U playlist")?;
     let mut quoted_path = OsString::from("\"");
     quoted_path.push(&path);
@@ -27,27 +143,6 @@ pub fn play(input: &str) -> Result<(), &'static str> {
         .map_err(|_| "cannot open M3U playlist")
 }
 
-fn parse_playlist(input: &str) -> Result<Url, &'static str> {
-    let encoded = input
-        .strip_prefix(M3U_DATA_URI_PREFIX)
-        .ok_or("unsupported external player")?;
-    let decoded = BASE64.decode(encoded).map_err(|_| "invalid playlist")?;
-    let playlist = String::from_utf8(decoded).map_err(|_| "invalid playlist")?;
-    let mut lines = playlist.lines();
-    if lines.next() != Some("#EXTM3U") || lines.next() != Some("#EXTINF:0") {
-        return Err("invalid playlist");
-    }
-    let url = lines.next().ok_or("invalid playlist")?;
-    if lines.next().is_some() || url.bytes().any(|byte| byte.is_ascii_whitespace()) {
-        return Err("invalid playlist");
-    }
-    let url = Url::parse(url).map_err(|_| "invalid playlist")?;
-    if !matches!(url.scheme(), "http" | "https") || url.host().is_none() {
-        return Err("playlist URL must be absolute HTTP(S)");
-    }
-    Ok(url)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -55,28 +150,57 @@ mod tests {
     const STREAM_URL: &str = "https://example.com/video.mkv?token=secret%2Bvalue";
 
     fn data_uri(playlist: &str) -> String {
-        format!("{M3U_DATA_URI_PREFIX}{}", BASE64.encode(playlist))
+        format!("{}{}", M3U_DATA_URI_PREFIX, BASE64.encode(playlist))
     }
 
     #[test]
-    fn accepts_core_playlist() {
-        let url = parse_playlist(&data_uri(&format!("#EXTM3U\n#EXTINF:0\n{STREAM_URL}"))).unwrap();
-        assert_eq!(url.as_str(), STREAM_URL);
+    fn accepts_core_forms() {
+        let stream = Url::parse(STREAM_URL).unwrap();
+        assert_eq!(
+            parse(&format!("vlc://{}", STREAM_URL)),
+            Ok(Request::Vlc(stream.clone()))
+        );
+        assert_eq!(
+            parse(&data_uri(&format!("#EXTM3U\n#EXTINF:0\n{}", STREAM_URL))),
+            Ok(Request::Playlist(stream))
+        );
     }
 
     #[test]
-    fn rejects_other_inputs() {
+    fn reads_program_from_open_with_command() {
+        assert_eq!(
+            command_program(r#""C:\Program Files\VideoLAN\VLC\vlc.exe" "%1""#),
+            Some(PathBuf::from(r"C:\Program Files\VideoLAN\VLC\vlc.exe"))
+        );
+        assert_eq!(
+            command_program(r#""C:\VLC\vlc.exe" -- "%L""#),
+            Some(PathBuf::from(r"C:\VLC\vlc.exe"))
+        );
+        assert_eq!(
+            command_program(r"C:\VLC\vlc.exe %1"),
+            Some(PathBuf::from(r"C:\VLC\vlc.exe"))
+        );
+        assert_eq!(command_program(""), None);
+    }
+
+    #[test]
+    fn rejects_unsafe_values() {
         for input in [
             "",
             "calc",
+            "file:///C:/Windows/System32/calc.exe",
             "mpv://https://example.com/video.mkv",
+            "vlc://file:///C:/Windows/System32/calc.exe",
+            "vlc://https://example.com/video.mkv\n--script=attack.lua",
+            "vlc://javascript:alert(1)",
+            "potplayer://https://example.com/video.mkv",
+            "iina://weblink?url=https%3A%2F%2Fexample.com%2Fvideo.mkv",
             &data_uri("#EXTM3U\n#EXTINF:0\nfile:///C:/Windows/System32/calc.exe"),
             &data_uri("#EXTM3U\n#EXTINF:0\nhttps://example.com/one\nhttps://example.com/two"),
             &data_uri("#EXTM3U\n#EXTINF:-1\nhttps://example.com/video.mkv"),
-            &data_uri("#EXTM3U\n#EXTINF:0\nhttps://example.com/a b"),
             "data:application/octet-stream;charset=utf-8;base64,not base64",
         ] {
-            assert!(parse_playlist(input).is_err(), "{}", input);
+            assert!(parse(input).is_err(), "{}", input);
         }
     }
 }

--- a/src/stremio_app/external_player.rs
+++ b/src/stremio_app/external_player.rs
@@ -1,0 +1,82 @@
+use std::{ffi::OsString, fs, os::windows::process::CommandExt, process::Command};
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use url::Url;
+use winapi::um::winbase::{CREATE_BREAKAWAY_FROM_JOB, CREATE_NO_WINDOW};
+
+const M3U_DATA_URI_PREFIX: &str = "data:application/octet-stream;charset=utf-8;base64,";
+
+pub fn play(input: &str) -> Result<(), &'static str> {
+    let stream_url = parse_playlist(input)?;
+    let directory = dirs::download_dir()
+        .ok_or("Downloads directory is unavailable")?
+        .join("Stremio");
+    fs::create_dir_all(&directory).map_err(|_| "cannot create playlist directory")?;
+    let path = directory.join("playlist.m3u");
+    fs::write(&path, format!("#EXTM3U\n#EXTINF:0\n{stream_url}"))
+        .map_err(|_| "cannot save M3U playlist")?;
+    let mut quoted_path = OsString::from("\"");
+    quoted_path.push(&path);
+    quoted_path.push("\"");
+    Command::new("cmd")
+        .args(["/C", "start", ""])
+        .raw_arg(quoted_path)
+        .creation_flags(CREATE_BREAKAWAY_FROM_JOB | CREATE_NO_WINDOW)
+        .spawn()
+        .map(drop)
+        .map_err(|_| "cannot open M3U playlist")
+}
+
+fn parse_playlist(input: &str) -> Result<Url, &'static str> {
+    let encoded = input
+        .strip_prefix(M3U_DATA_URI_PREFIX)
+        .ok_or("unsupported external player")?;
+    let decoded = BASE64.decode(encoded).map_err(|_| "invalid playlist")?;
+    let playlist = String::from_utf8(decoded).map_err(|_| "invalid playlist")?;
+    let mut lines = playlist.lines();
+    if lines.next() != Some("#EXTM3U") || lines.next() != Some("#EXTINF:0") {
+        return Err("invalid playlist");
+    }
+    let url = lines.next().ok_or("invalid playlist")?;
+    if lines.next().is_some() || url.bytes().any(|byte| byte.is_ascii_whitespace()) {
+        return Err("invalid playlist");
+    }
+    let url = Url::parse(url).map_err(|_| "invalid playlist")?;
+    if !matches!(url.scheme(), "http" | "https") || url.host().is_none() {
+        return Err("playlist URL must be absolute HTTP(S)");
+    }
+    Ok(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const STREAM_URL: &str = "https://example.com/video.mkv?token=secret%2Bvalue";
+
+    fn data_uri(playlist: &str) -> String {
+        format!("{M3U_DATA_URI_PREFIX}{}", BASE64.encode(playlist))
+    }
+
+    #[test]
+    fn accepts_core_playlist() {
+        let url = parse_playlist(&data_uri(&format!("#EXTM3U\n#EXTINF:0\n{STREAM_URL}"))).unwrap();
+        assert_eq!(url.as_str(), STREAM_URL);
+    }
+
+    #[test]
+    fn rejects_other_inputs() {
+        for input in [
+            "",
+            "calc",
+            "mpv://https://example.com/video.mkv",
+            &data_uri("#EXTM3U\n#EXTINF:0\nfile:///C:/Windows/System32/calc.exe"),
+            &data_uri("#EXTM3U\n#EXTINF:0\nhttps://example.com/one\nhttps://example.com/two"),
+            &data_uri("#EXTM3U\n#EXTINF:-1\nhttps://example.com/video.mkv"),
+            &data_uri("#EXTM3U\n#EXTINF:0\nhttps://example.com/a b"),
+            "data:application/octet-stream;charset=utf-8;base64,not base64",
+        ] {
+            assert!(parse_playlist(input).is_err(), "{}", input);
+        }
+    }
+}

--- a/src/stremio_app/mod.rs
+++ b/src/stremio_app/mod.rs
@@ -1,6 +1,7 @@
 pub mod app;
 pub use app::MainWindow;
 pub mod discord;
+pub mod external_player;
 pub mod gpu_video_processing;
 pub mod ipc;
 pub mod stremio_player;

--- a/src/stremio_app/stremio_wevbiew/wevbiew.rs
+++ b/src/stremio_app/stremio_wevbiew/wevbiew.rs
@@ -184,7 +184,7 @@ impl PartialUi for WebView {
                                 document.addEventListener('click', event => {
                                     const link = event.target.closest('a[href]');
                                     const href = link && link.getAttribute('href');
-                                    if (href && href.startsWith('data:application/octet-stream;charset=utf-8;base64,')) {
+                                    if (href && (href.startsWith('data:application/octet-stream;charset=utf-8;base64,') || /^vlc:/i.test(href))) {
                                         event.preventDefault();
                                         window.chrome.webview.postMessage(JSON.stringify({id: 1, args: ['play-external', href]}));
                                     }

--- a/src/stremio_app/stremio_wevbiew/wevbiew.rs
+++ b/src/stremio_app/stremio_wevbiew/wevbiew.rs
@@ -181,6 +181,14 @@ impl PartialUi for WebView {
                             try{console.log('Shell JS injected');if(window.self === window.top) {
                                 window.qt={webChannelTransport:{send:window.chrome.webview.postMessage}};
                                 window.chrome.webview.addEventListener('message',ev=>window.qt.webChannelTransport.onmessage(ev));
+                                document.addEventListener('click', event => {
+                                    const link = event.target.closest('a[href]');
+                                    const href = link && link.getAttribute('href');
+                                    if (href && href.startsWith('data:application/octet-stream;charset=utf-8;base64,')) {
+                                        event.preventDefault();
+                                        window.chrome.webview.postMessage(JSON.stringify({id: 1, args: ['play-external', href]}));
+                                    }
+                                }, true);
                                 }}catch(e){}
                             window.addEventListener("load", function() {if(initShellComm) try { initShellComm() } catch(e) {}}, false)
 

--- a/src/stremio_app/stremio_wevbiew/wevbiew.rs
+++ b/src/stremio_app/stremio_wevbiew/wevbiew.rs
@@ -137,6 +137,24 @@ impl PartialUi for WebView {
                         Ok(())
                     })?;
 
+                    let trusted_origin = endpoint
+                        .get()
+                        .and_then(|endpoint| url::Url::parse(endpoint).ok())
+                        .map(|endpoint| endpoint.origin());
+                    let navigation_origin = trusted_origin.clone();
+                    webview.add_navigation_starting(move |_webview, event| {
+                        let uri = event.get_uri()?;
+                        if !same_origin(&navigation_origin, &uri) {
+                            event.put_cancel(true)?;
+                            if let Some(final_url) = safe_url(&uri) {
+                                if let Err(e) = open::that(final_url) {
+                                    eprintln!("Failed to open URL: {e}");
+                                }
+                            }
+                        }
+                        Ok(())
+                    })?;
+
                     if let Some(endpoint) = endpoint.get() {
                         if webview
                             .navigate(endpoint.as_str()).is_err() {
@@ -144,6 +162,11 @@ impl PartialUi for WebView {
                         };
                     }
                         webview.add_web_message_received(move |_w, msg| {
+                            let source = msg.get_source()?;
+                            if !same_origin(&trusted_origin, &source) {
+                                eprintln!("Ignored web message from {source}");
+                                return Ok(());
+                            }
                             let msg = msg.try_get_web_message_as_string()?;
                             tx_web.send(msg).ok();
                             Ok(())
@@ -310,5 +333,12 @@ impl PartialUi for WebView {
                 }
             }
         }
+    }
+}
+
+fn same_origin(trusted: &Option<url::Origin>, uri: &str) -> bool {
+    match trusted {
+        Some(trusted) => url::Url::parse(uri).is_ok_and(|url| url.origin() == *trusted),
+        None => false,
     }
 }


### PR DESCRIPTION
Restores `play-external` on Windows for VLC and the M3U playlist.

Depends on Stremio/stremio-core#1042 and Stremio/stremio-web#1412 for VLCto be offered on Windows; the M3U path works with today's web.
