### PR TITLE
Add native interface zoom

### DIFF
--- a/src/stremio_app/app.rs
+++ b/src/stremio_app/app.rs
@@ -47,6 +47,7 @@ pub struct MainWindow {
     pub release_candidate: bool,
     pub autoupdater_setup_file: Arc<Mutex<Option<PathBuf>>>,
     pub requested_fullscreen: Arc<Mutex<Option<bool>>>,
+    pub requested_interface_scale: Arc<Mutex<Option<u64>>>,
     pub saved_window_style: RefCell<WindowStyle>,
     #[nwg_resource]
     pub embed: nwg::EmbedResource,
@@ -83,6 +84,9 @@ pub struct MainWindow {
     #[nwg_control]
     #[nwg_events(OnNotice: [Self::on_toggle_fullscreen_notice] )]
     pub toggle_fullscreen_notice: nwg::Notice,
+    #[nwg_control]
+    #[nwg_events(OnNotice: [Self::on_set_interface_scale_notice] )]
+    pub set_interface_scale_notice: nwg::Notice,
     #[nwg_control]
     #[nwg_events(OnNotice: [nwg::stop_thread_dispatch()] )]
     pub quit_notice: nwg::Notice,
@@ -265,6 +269,7 @@ impl MainWindow {
         }); // thread
 
         let toggle_fullscreen_sender = self.toggle_fullscreen_notice.sender();
+        let set_interface_scale_sender = self.set_interface_scale_notice.sender();
         let quit_sender = self.quit_notice.sender();
         let hide_splash_sender = self.hide_splash_notice.sender();
         let focus_sender = self.focus_notice.sender();
@@ -272,6 +277,7 @@ impl MainWindow {
 
         let discord_rpc = DiscordRpc::new(web_tx.clone());
         let requested_fullscreen = self.requested_fullscreen.clone();
+        let requested_interface_scale = self.requested_interface_scale.clone();
 
         thread::spawn(move || loop {
             if let Some(msg) = web_rx
@@ -283,6 +289,17 @@ impl MainWindow {
                     // The handshake. Here we send some useful data to the WEB UI
                     None if msg.is_handshake() => {
                         web_tx_web.send(RPCResponse::get_handshake()).ok();
+                    }
+                    Some("win-set-interface-scale") => {
+                        if let Some(scale) = msg
+                            .get_params()
+                            .and_then(|params| params.get("scale"))
+                            .and_then(|value| value.as_u64())
+                            .filter(|scale| (75..=175).contains(scale))
+                        {
+                            *requested_interface_scale.lock().unwrap() = Some(scale);
+                            set_interface_scale_sender.notice();
+                        }
                     }
                     Some("win-set-visibility") => {
                         if let Some(fullscreen) = msg
@@ -518,6 +535,12 @@ impl MainWindow {
             }
         }
         self.transmit_window_visibility_change();
+    }
+    fn on_set_interface_scale_notice(&self) {
+        let scale = self.requested_interface_scale.lock().unwrap().take();
+        if let Some(scale) = scale {
+            self.webview.set_interface_scale(scale);
+        }
     }
     fn on_hide_splash_notice(&self) {
         self.splash_screen.hide();

--- a/src/stremio_app/ipc.rs
+++ b/src/stremio_app/ipc.rs
@@ -76,6 +76,12 @@ impl RPCResponse {
                             "".to_string(),
                             gpu_video_processing::gpu_video_processing_supported().to_string(),
                         ],
+                        vec![
+                            "".to_string(),
+                            "nativeInterfaceScale".to_string(),
+                            "".to_string(),
+                            "true".to_string(),
+                        ],
                     ],
                     signals: vec![],
                     methods: vec![vec!["onEvent".to_string(), "".to_string()]],

--- a/src/stremio_app/stremio_wevbiew/wevbiew.rs
+++ b/src/stremio_app/stremio_wevbiew/wevbiew.rs
@@ -39,6 +39,14 @@ pub struct WebView {
 }
 
 impl WebView {
+    pub fn set_interface_scale(&self, scale: u64) {
+        if let Some(controller) = self.controller.get() {
+            if let Err(error) = controller.put_zoom_factor(scale as f64 / 100.0) {
+                eprintln!("Cannot set interface scale: {error}");
+            }
+        }
+    }
+
     pub fn fit_to_window(&self, hwnd: Option<HWND>) {
         if let Some(hwnd) = hwnd {
             unsafe {
@@ -110,6 +118,7 @@ impl PartialUi for WebView {
                     settings.put_is_status_bar_enabled(false).ok();
                     settings.put_are_dev_tools_enabled(true).ok();
                     settings.put_are_default_context_menus_enabled(true).ok();
+                    // Web handles zoom shortcuts so they update the saved interface scale.
                     settings.put_is_zoom_control_enabled(false).ok();
                     settings.put_is_built_in_error_page_enabled(false).ok();
                     settings.put_are_host_objects_allowed(false).ok();


### PR DESCRIPTION
Companion to Stremio/stremio-web#1195. Uses WebView2 page zoom for the saved Interface zoom setting and Web's Ctrl +/−/0 shortcuts.

Windows CI and Web/IPC shortcut checks pass. Manual Windows playback testing is pending.
